### PR TITLE
Add Hide Badge toggle and Disclaimer message

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,5 @@ This will automatically render the reCAPTCHA element on the page (if a valid `SI
 As of v2.0, Recaptcha also supports the [Invisible reCAPTCHA](https://developers.google.com/recaptcha/docs/invisible):
 
 1. Simply turn on the `Invisible` toggle in Recaptcha's settings.
+2. Turn on `Hide Badge` to hide Recaptcha badge
+3. Add required Google Terms and Privacy Policy using `{{ recaptcha:disclaimer }}`

--- a/Recaptcha/RecaptchaTags.php
+++ b/Recaptcha/RecaptchaTags.php
@@ -28,7 +28,9 @@ class RecaptchaTags extends Tags
         if (! $this->get('invisible', false)) {
             return '<script src="https://www.google.com/recaptcha/api.js" async defer></script>';
         } else {
-            return '
+            $hide_badge = $this->get('hide_badge', false) ? '<style>.grecaptcha-badge { visibility: collapse !important }</style>"' : '';
+            
+            return $hide_badge . '
                 <script>
                     var recaptchaCallback = function (form) {
                         return function () {
@@ -64,6 +66,16 @@ class RecaptchaTags extends Tags
         }
     }
 
+    /**
+     * The {{ recaptcha:disclaimer }} tag
+     *
+     * @return string
+     */
+    public function disclaimer()
+    {   
+        return markdown($this->get('disclaimer'));
+    }
+    
     /**
      * Get the current domain's site key
      *

--- a/Recaptcha/settings.yaml
+++ b/Recaptcha/settings.yaml
@@ -9,6 +9,19 @@ fields:
   error_message:
     type: text
     instructions: The message that will be returned if validation fails.
+  hide_badge:
+    display: Hide reCAPTCHA Badge
+    instructions: Replace badge with reCAPTCHA Disclaimer Message
+    type: toggle
+  disclaimer:
+    display: Disclaimer Message
+    instructions: The message shown when reCaptcha badge is hidden
+    type: markdown
+    show_when:
+      hide_badge: true
+    default: "This site is protected by reCAPTCHA and the Google
+    [Privacy Policy](https://policies.google.com/privacy) and
+    [Terms of Service](https://policies.google.com/terms) apply."
   keys_section:
     type: section
     display: reCAPTCHA API Keys


### PR DESCRIPTION
Additional settings to visually hide floating reCAPTCHA v2 badge with CSS. When doing this, Google requires you display a form disclaimer with their Privacy Policy and Terms of Service.

Default Disclaimer message:
```
This site is protected by reCAPTCHA and the Google
    [Privacy Policy](https://policies.google.com/privacy) and
    [Terms of Service](https://policies.google.com/terms) apply."
```